### PR TITLE
Creating new data stub module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# v2
+
+* Added in a data sub-module that takes the same arguments, but only returns an
+  existing VPC's variables in output.  This is meant to be used in situations
+  where you have a separate state file in the same account as a VPC resource
+  that's already been set up, to use that VPC as a data source.
+
+# v1
+
+* First release

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,25 @@
+# Overview
+
+This module is a representation of the VPC module in the parent directory, but
+one which only loads values as a data source.  The intent is to make it easier
+for us to have people include this version of the module when they wish to
+work against an existing shared VPC in development, then not have to make major
+changes to multiple places that are including data from the module.  Doing as a
+bare data source means having to potentially update a number of variables for
+subnets when you move over.
+
+This should be kept in sync with any changes to the parent directory's inputs
+and outputs.
+
+# Variables
+
+See variables.tf for all current variables and descriptions.
+
+# Resources
+
+This only uses local variables and data sources needed to mimic the parent
+directory.
+
+# Outputs
+
+See output.tf for all current outputs.

--- a/data/main.tf
+++ b/data/main.tf
@@ -1,0 +1,24 @@
+#######################################################################
+# VPC itself
+#######################################################################
+
+data "aws_availability_zones" "available" {}
+
+data "aws_vpc" "selected" {
+  cidr_block = "10.0.0.0/16"
+
+  filter {
+    name   = "tag:Name"
+    values = ["${var.environment}"]
+  }
+}
+
+locals {
+  public_subnets       = ["10.0.0.0/24",   "10.0.1.0/24",   "10.0.2.0/24"]
+  private_subnets      = ["10.0.64.0/24",  "10.0.65.0/24",  "10.0.66.0/24"]
+  database_subnets     = ["10.0.128.0/24", "10.0.129.0/24", "10.0.130.0/24"]
+}
+
+#  azs      = ["${data.aws_availability_zones.available.names[0]}",
+#              "${data.aws_availability_zones.available.names[1]}",
+#              "${data.aws_availability_zones.available.names[2]}"]

--- a/data/output.tf
+++ b/data/output.tf
@@ -1,0 +1,25 @@
+output "vpc_id" {
+  value = "${data.aws_vpc.selected.id}"
+}
+
+output "public_subnets" {
+  value = "${join(",", local.public_subnets)}"
+}
+
+output "private_subnets" {
+  value = "${join(",", local.private_subnets)}"
+}
+
+output "database_subnets" {
+  value = "${join(",", local.database_subnets)}"
+}
+
+# There's no reader for the two subnet_group resources, but the id is the name
+# and the name is set to the environment.
+output "database_subnet_group" {
+  value = "${var.environment}"
+}
+
+output "elasticache_subnet_group" {
+  value = "${var.environment}"
+}

--- a/data/variables.tf
+++ b/data/variables.tf
@@ -1,0 +1,18 @@
+variable "environment" {
+  description = "Environment, used to name the VPC itself and as part of the name for other resources"
+}
+
+variable "enable_s3_endpoint" {
+  description = "Whether to create an S3 endpoint to the private network"
+  default     = false
+}
+
+variable "enable_dynamodb_endpoint" {
+  description = "Whether to create a DynamoDB endpoint to the private network"
+  default     = false
+}
+
+variable "enable_kinesis_endpoint" {
+  description = "Whether to create a Kinesis endpoint to the private network"
+  default     = false
+}


### PR DESCRIPTION
This will act as the normal module, but rather than create resources,
it acts as a wrapper to return the data for an existing VPC.  This can
be used by developers who are doing their own work in a directory or
branch separated from the main state.