### PR TITLE
Fix issue with subnetid ids

### DIFF
--- a/data/main.tf
+++ b/data/main.tf
@@ -13,12 +13,67 @@ data "aws_vpc" "selected" {
   }
 }
 
-locals {
-  public_subnets       = ["10.0.0.0/24",   "10.0.1.0/24",   "10.0.2.0/24"]
-  private_subnets      = ["10.0.64.0/24",  "10.0.65.0/24",  "10.0.66.0/24"]
-  database_subnets     = ["10.0.128.0/24", "10.0.129.0/24", "10.0.130.0/24"]
+data "aws_subnet" "public1" {
+  vpc_id     = "${data.aws_vpc.selected.id}"
+  cidr_block = "10.0.0.0/24"
 }
 
-#  azs      = ["${data.aws_availability_zones.available.names[0]}",
-#              "${data.aws_availability_zones.available.names[1]}",
-#              "${data.aws_availability_zones.available.names[2]}"]
+data "aws_subnet" "public2" {
+  vpc_id     = "${data.aws_vpc.selected.id}"
+  cidr_block = "10.0.1.0/24"
+}
+
+data "aws_subnet" "public3" {
+  vpc_id     = "${data.aws_vpc.selected.id}"
+  cidr_block = "10.0.2.0/24"
+}
+
+data "aws_subnet" "private1" {
+  vpc_id     = "${data.aws_vpc.selected.id}"
+  cidr_block = "10.0.64.0/24"
+}
+
+data "aws_subnet" "private2" {
+  vpc_id     = "${data.aws_vpc.selected.id}"
+  cidr_block = "10.0.65.0/24"
+}
+
+data "aws_subnet" "private3" {
+  vpc_id     = "${data.aws_vpc.selected.id}"
+  cidr_block = "10.0.66.0/24"
+}
+
+data "aws_subnet" "db1" {
+  vpc_id     = "${data.aws_vpc.selected.id}"
+  cidr_block = "10.0.128.0/24"
+}
+
+data "aws_subnet" "db2" {
+  vpc_id     = "${data.aws_vpc.selected.id}"
+  cidr_block = "10.0.129.0/24"
+}
+
+data "aws_subnet" "db3" {
+  vpc_id     = "${data.aws_vpc.selected.id}"
+  cidr_block = "10.0.130.0/24"
+}
+
+
+locals {
+  public_subnets   = [
+                      "${data.aws_subnet.public1.id}",
+                      "${data.aws_subnet.public2.id}",
+                      "${data.aws_subnet.public3.id}",
+                      "fred",
+                     ]
+  private_subnets  = [
+                      "${data.aws_subnet.private1.id}",
+                      "${data.aws_subnet.private2.id}",
+                      "${data.aws_subnet.private3.id}",
+                     ]
+  database_subnets = [
+                      "${data.aws_subnet.db1.id}",
+                      "${data.aws_subnet.db2.id}",
+                      "${data.aws_subnet.db3.id}",
+                     ]
+}


### PR DESCRIPTION
For the data sub-module we were returning the subnets as a list of
cidr blocks, rather than the actual subnet ids.  Updated to query and
return the actual subnet blocks.