### PR TITLE
Fix issue with sunetid ids

### DIFF
--- a/data/main.tf
+++ b/data/main.tf
@@ -64,7 +64,6 @@ locals {
                       "${data.aws_subnet.public1.id}",
                       "${data.aws_subnet.public2.id}",
                       "${data.aws_subnet.public3.id}",
-                      "fred",
                      ]
   private_subnets  = [
                       "${data.aws_subnet.private1.id}",


### PR DESCRIPTION
For the data sub-module we were returning the subnets as a list of
cidr blocks, rather than the actual subnet ids.  Updated to query and
return the actual subnet blocks.