### PR TITLE
Remove redundant depends_on statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v3
+
+* Remove unneeded depends_on statements.
+
 # v2
 
 * Added in a data sub-module that takes the same arguments, but only returns an

--- a/main.tf
+++ b/main.tf
@@ -53,8 +53,6 @@ resource "aws_vpc_endpoint_route_table_association" "private_s3" {
 
   vpc_endpoint_id = "${aws_vpc_endpoint.s3.id}"
   route_table_id  = "${element(module.vpc.private_route_table_ids, count.index)}"
-
-  depends_on = ["module.vpc", "aws_vpc_endpoint.s3"]
 }
 
 # dynamodb
@@ -76,7 +74,6 @@ resource "aws_vpc_endpoint_route_table_association" "private_dynamodb" {
 
   vpc_endpoint_id = "${aws_vpc_endpoint.dynamodb.id}"
   route_table_id  = "${element(module.vpc.private_route_table_ids, count.index)}"
-  depends_on = ["module.vpc", "aws_vpc_endpoint.dynamodb"]
 }
 
 # create a kinesis endpoint service for the private subnets


### PR DESCRIPTION
Explicit `depends_on` is an anti-pattern for values that otherwise already appear in the body of the resource.

There *used* to be a terraform bug whereby dependencies were lost for resources that included a `count`, but that was [fixed over a year ago](https://github.com/hashicorp/terraform/issues/16486).