### PR TITLE
Use lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v6
+
+* Deprecated `//data` outputs that joined strings w/ commas, e.g. `public_subnets`
+* Provided proper list outputs as replacements, e.g. `public_subnet_ids`.  
+
 # v5
 
 * Removed unused variables from `//data`.

--- a/data/README.md
+++ b/data/README.md
@@ -8,18 +8,16 @@ changes to multiple places that are including data from the module.  Doing as a
 bare data source means having to potentially update a number of variables for
 subnets when you move over.
 
-This should be kept in sync with any changes to the parent directory's inputs
-and outputs.
+This **must** be kept in sync with any changes to the parent directory's inputs and outputs.
 
 # Variables
 
-See variables.tf for all current variables and descriptions.
+See `variables.tf` for all current variables and descriptions.
 
 # Resources
 
-This only uses local variables and data sources needed to mimic the parent
-directory.
+This only uses local variables and data sources needed to mimic the parent directory.
 
 # Outputs
 
-See output.tf for all current outputs.
+See `output.tf` for all current outputs.

--- a/data/output.tf
+++ b/data/output.tf
@@ -2,20 +2,32 @@ output "vpc_id" {
   value = "${data.aws_vpc.selected.id}"
 }
 
-output "public_subnets" {
+output "public_subnets" { # deprecated
   value = "${join(",", local.public_subnets)}"
 }
+output "public_subnet_ids" { # a proper list
+  value = ["${local.public_subnets}"]
+}
 
-output "private_subnets" {
+output "private_subnets" { # deprecated
   value = "${join(",", local.private_subnets)}"
 }
-
-output "database_subnets" {
-  value = "${join(",", local.database_subnets)}"
+output "private_subnet_ids" { # a proper list
+  value = ["${local.private_subnets}"]
 }
 
-output "elasticache_subnets" {
+output "database_subnets" { # deprecated
+  value = "${join(",", local.database_subnets)}"
+}
+output "database_subnet_ids" { # a proper list
+  value = ["${local.database_subnets}"]
+}
+
+output "elasticache_subnets" { # deprecated
   value = "${join(",", local.elasticache_subnets)}"
+}
+output "elasticache_subnet_ids" { # a proper list
+  value = ["${local.elasticache_subnets}"]
 }
 
 # There's no reader for the two subnet_group resources, but the id is the name


### PR DESCRIPTION
This doesn't touch the old `join`'d outputs, but creates proper list outputs side-by-side.  We would purge usage of the old outputs in consumers, convert them to the new then remove the old ones here.

To test, from the repo root:
```
mkdir exp
cd exp
cp ~/someplace/terraform.tfvars ./
```
Create a `main.tf` with:
```hcl
variable "profile" {}

provider "aws" {
  alias   = "us-west-2"
  region  = "us-west-2"
  profile = "${var.profile}"
  version = "1.50.0"

  assume_role {
    role_arn     = "arn:aws:iam::418214828013:role/DevelopersRole"
    session_name = "terraform"
  }
}
provider "vault" { version = "1.1" }
provider "template" { version = "1.0" }
provider "random" { version = "1.3" }

module "experimental" {
  source = "..//data"
  providers { aws = "aws.us-west-2" }
  environment = "development"
}

output "private_subnets" {
  value = "${module.experimental.private_subnets}"
}
output "private_subnet_ids" {
  value = ["${module.experimental.private_subnet_ids}"]
}
```

Run `terraform init` and `terraform apply`.  Output includes:
```hcl
Outputs:

private_subnet_ids = [
    subnet-0bbfc2b2c2a17d95f,
    subnet-00a7afb6b2ca6ed58,
    subnet-02880b2ce99f86a81
]
private_subnets = subnet-0bbfc2b2c2a17d95f,subnet-00a7afb6b2ca6ed58,subnet-02880b2ce99f86a81
```

Addresses #7 for `data`.